### PR TITLE
updated to latest recommended Forge

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,14 +11,14 @@ buildscript {
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 
-version = '2.3.1'
+version = '2.3.2'
 group = 'shadows.apotheosis'
 archivesBaseName = 'Apotheosis-1.14.4'
 
 sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8'
 
 minecraft {
-    mappings channel: 'snapshot', version: '20190829-1.14.3'
+    mappings channel: 'snapshot', version: '20190912-1.14.3'
     accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
     runs {
         client = {
@@ -46,7 +46,7 @@ repositories {
 }
 
 dependencies {
-    minecraft 'net.minecraftforge:forge:1.14.4-28.0.93'
+    minecraft 'net.minecraftforge:forge:1.14.4-28.1.1'
 	compile fg.deobf('mezz.jei:jei-1.14.4:+')
 	compile fg.deobf('mcp.mobius.waila:Hwyla:1.10+')
 	compile fileTree(dir: 'libs', include: '*.jar')

--- a/src/main/java/shadows/deadly/DeadlyModule.java
+++ b/src/main/java/shadows/deadly/DeadlyModule.java
@@ -44,7 +44,7 @@ public class DeadlyModule {
 	}
 
 	public void death(LivingDeathEvent e) {
-		if (e.getEntity().getPersistantData().getBoolean("apoth_boss")) {
+		if (e.getEntity().getPersistentData().getBoolean("apoth_boss")) {
 			DamageSource source = e.getSource();
 			if (source.getTrueSource() instanceof ServerPlayerEntity) {
 				AdvancementTriggers.BOSS_TRIGGER.trigger(((ServerPlayerEntity) source.getTrueSource()).getAdvancements());

--- a/src/main/java/shadows/deadly/gen/BossItem.java
+++ b/src/main/java/shadows/deadly/gen/BossItem.java
@@ -111,7 +111,7 @@ public class BossItem extends WorldFeatureItem {
 		for (BlockPos p : BlockPos.getAllInBoxMutable(pos.add(-2, -2, -2), pos.add(2, -2, 2))) {
 			world.setBlockState(p, Blocks.RED_SANDSTONE.getDefaultState(), 2);
 		}
-		entity.getPersistantData().putBoolean("apoth_boss", true);
+		entity.getPersistentData().putBoolean("apoth_boss", true);
 		WorldGenerator.debugLog(pos, "Boss " + entity.getName().getUnformattedComponentText());
 	}
 

--- a/src/main/java/shadows/village/fletching/arrows/ObsidianArrowItem.java
+++ b/src/main/java/shadows/village/fletching/arrows/ObsidianArrowItem.java
@@ -28,7 +28,7 @@ public class ObsidianArrowItem extends ArrowItem {
 	@Override
 	public AbstractArrowEntity createArrow(World world, ItemStack stack, LivingEntity shooter) {
 		AbstractArrowEntity e = new ObsidianArrowEntity(shooter, world);
-		e.getPersistantData().putBoolean("apoth_obsidian_arrow", true);
+		e.getPersistentData().putBoolean("apoth_obsidian_arrow", true);
 		return e;
 	}
 
@@ -42,9 +42,9 @@ public class ObsidianArrowItem extends ArrowItem {
 	public void handleArrowJoin(EntityJoinWorldEvent e) {
 		if (!e.getWorld().isRemote && e.getEntity() instanceof AbstractArrowEntity) {
 			AbstractArrowEntity ent = (AbstractArrowEntity) e.getEntity();
-			if (ent.getPersistantData().getBoolean("apoth_obsidian_arrow")) {
+			if (ent.getPersistentData().getBoolean("apoth_obsidian_arrow")) {
 				ent.setDamage(ent.getDamage() * 1.2F);
-				ent.getPersistantData().remove("apoth_obsidian_arrow");
+				ent.getPersistentData().remove("apoth_obsidian_arrow");
 			}
 		}
 	}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -19,7 +19,7 @@ All things that should have been.
 [[dependencies.apotheosis]] #optional
     modId="forge" #mandatory
     mandatory=true #mandatory
-    versionRange="[28.0.93,)" #mandatory
+    versionRange="[28.1,)" #mandatory
     ordering="NONE"
     side="BOTH"
 


### PR DESCRIPTION
- bumped version patch level
- bumped minimum Forge version to 28.1, build against 28.1.1
- updated mappings version to 20190912-1.14.3
- updated to the proper name of Entity#getPersistentData (breaking)
