### PR TITLE
Properly fix issue with Lure levels (#54)

### DIFF
--- a/src/main/java/shadows/apotheosis/ench/EnchModule.java
+++ b/src/main/java/shadows/apotheosis/ench/EnchModule.java
@@ -165,7 +165,12 @@ public class EnchModule {
 		recalcAbsMax();
 		config = new Configuration(new File(Apotheosis.configDir, "enchantments.cfg"));
 		for (Enchantment ench : ForgeRegistries.ENCHANTMENTS) {
-			int max = config.getInt("Max Level", ench.getRegistryName().toString(), getDefaultMax(ench), 1, 127, "The max level of this enchantment.");
+			int max;
+			if (ench == Enchantments.LURE) {
+				max = config.getInt("Max Level", ench.getRegistryName().toString(), ench.getMaxLevel(), 1, ench.getMaxLevel(), "The max level of this enchantment.");
+			} else {
+				max = config.getInt("Max Level", ench.getRegistryName().toString(), getDefaultMax(ench), 1, 127, "The max level of this enchantment.");
+			}
 			int min = config.getInt("Min Level", ench.getRegistryName().toString(), ench.getMinLevel(), 1, 127, "The min level of this enchantment.");
 			if (min > max) min = max;
 			EnchantmentInfo info = new EnchantmentInfo(ench, max, min);
@@ -532,9 +537,13 @@ public class EnchModule {
 			return new EnchantmentInfo(ench, ench.getMaxLevel(), ench.getMinLevel());
 		}
 		if (info == null) {
-			int max = enchInfoConfig.getInt("Max Level", ench.getRegistryName().toString(), ench.getMaxLevel(), 1, 127, "The max level of this enchantment.");
+			int max;
+			if (ench == Enchantments.LURE) {
+				max = enchInfoConfig.getInt("Max Level", ench.getRegistryName().toString(), ench.getMaxLevel(), 1, ench.getMaxLevel(), "The max level of this enchantment.");
+			} else {
+				max = enchInfoConfig.getInt("Max Level", ench.getRegistryName().toString(), getDefaultMax(ench), 1, 127, "The max level of this enchantment.");
+			}
 			int min = enchInfoConfig.getInt("Min Level", ench.getRegistryName().toString(), ench.getMinLevel(), 1, 127, "The min level of this enchantment.");
-			if (ench == Enchantments.LURE) max = Enchantments.LURE.getMaxLevel();
 			if (min > max) min = max;
 			info = new EnchantmentInfo(ench, max, min);
 			String maxF = enchInfoConfig.getString("Max Power Function", ench.getRegistryName().toString(), "", "A function to determine the max enchanting power.  The variable \"x\" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples");

--- a/src/main/java/shadows/apotheosis/ench/EnchModule.java
+++ b/src/main/java/shadows/apotheosis/ench/EnchModule.java
@@ -537,12 +537,7 @@ public class EnchModule {
 			return new EnchantmentInfo(ench, ench.getMaxLevel(), ench.getMinLevel());
 		}
 		if (info == null) {
-			int max;
-			if (ench == Enchantments.LURE) {
-				max = enchInfoConfig.getInt("Max Level", ench.getRegistryName().toString(), ench.getMaxLevel(), 1, ench.getMaxLevel(), "The max level of this enchantment.");
-			} else {
-				max = enchInfoConfig.getInt("Max Level", ench.getRegistryName().toString(), getDefaultMax(ench), 1, 127, "The max level of this enchantment.");
-			}
+			int max = enchInfoConfig.getInt("Max Level", ench.getRegistryName().toString(), getDefaultMax(ench), 1, 127, "The max level of this enchantment.");
 			int min = enchInfoConfig.getInt("Min Level", ench.getRegistryName().toString(), ench.getMinLevel(), 1, 127, "The min level of this enchantment.");
 			if (min > max) min = max;
 			info = new EnchantmentInfo(ench, max, min);


### PR DESCRIPTION
The previous fix for #54 (commit: a9952361d2f255895c6add21c171d42f0b09ebcd) only applied the special casing for the Lure enchantment in `EnchModule#getEnchInfo` and only if the `EnchModule.ENCHANTMENT_INFO` map didn't already have an entry for it, however, the map is already populated in `EnchModule#init` so the code block that the special casing is in never executes.

This applies the special casing in `EnchModule#init` and also applies it to the config so that the config also show the correct values. (The config setting is pretty much pointless, but kept for posterity.)
