### PR TITLE
TileSpawnerExt was not correctly writing ignoresCap.

### DIFF
--- a/src/main/java/shadows/apotheosis/spawn/TileSpawnerExt.java
+++ b/src/main/java/shadows/apotheosis/spawn/TileSpawnerExt.java
@@ -39,7 +39,7 @@ public class TileSpawnerExt extends MobSpawnerTileEntity {
 	public CompoundNBT write(CompoundNBT tag) {
 		tag.putBoolean("ignore_players", ignoresPlayers);
 		tag.putBoolean("ignore_conditions", ignoresConditions);
-		tag.putBoolean("ignore_cap", ignoresPlayers);
+		tag.putBoolean("ignore_cap", ignoresCap);
 		tag.putBoolean("redstone_control", redstoneEnabled);
 		return super.write(tag);
 	}


### PR DESCRIPTION
TileSpawnerExt was writing the value of ignoresPlayers instead of ignoresCap, resulting in the spawner forgetting that the cap should be ignored when the NBT tag gets reloaded.