### PR TITLE
[1.12] Backport #120 / Spawner NBT Confusion

### DIFF
--- a/src/main/java/shadows/spawn/TileSpawnerExt.java
+++ b/src/main/java/shadows/spawn/TileSpawnerExt.java
@@ -36,7 +36,7 @@ public class TileSpawnerExt extends TileEntityMobSpawner {
 	public NBTTagCompound writeToNBT(NBTTagCompound tag) {
 		tag.setBoolean("ignore_players", ignoresPlayers);
 		tag.setBoolean("ignore_conditions", ignoresConditions);
-		tag.setBoolean("ignore_cap", ignoresPlayers);
+		tag.setBoolean("ignore_cap", ignoresCap);
 		tag.setBoolean("redstone_control", redstoneEnabled);
 		return super.writeToNBT(tag);
 	}


### PR DESCRIPTION
#120 fixed an issue where the spawn cap upgrade was overwritten by the player range upgrade, but the patch is only in the 1.14 and 1.15 branches.

A few thousand witches wanted a word with me and my framerate when I signed on to my PO3 server this morning :).
