### PR TITLE
Fix #370 tools repairable with any items

### DIFF
--- a/src/main/resources/coremods/mythics_anvil.js
+++ b/src/main/resources/coremods/mythics_anvil.js
@@ -33,7 +33,7 @@ function initializeCoreMod() {
                     var n = instr.get(i);
                     if (n.getOpcode() == Opcodes.INVOKEVIRTUAL && n.name.equals(ASMAPI.mapMethod('func_77984_f'))) {
                         ix++;
-						instr.set(n, hook);
+                        instr.set(n, hook.clone({}));
                     }
                 }
 


### PR DESCRIPTION
Closes #370

This PR fixes a bug in the `mythics_anvil.js` coremod.

The `hook`, which is a `MethodInsnNode` has to be recreated (or cloned) each time you want to insert it into an `InsnList` because it holds references to the instructions before and after it (and they hold references to it).

Went with cloning because it looks cleaner and is a smaller change.

Feel free to close PR if you wanna implement differently.