### PR TITLE
add config options for disabling enchant module enchantments individually

### DIFF
--- a/src/main/java/shadows/apotheosis/ench/EnchModule.java
+++ b/src/main/java/shadows/apotheosis/ench/EnchModule.java
@@ -6,6 +6,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import net.minecraft.enchantment.*;
+import net.minecraftforge.fml.event.lifecycle.FMLConstructModEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -20,11 +22,7 @@ import net.minecraft.block.Blocks;
 import net.minecraft.block.DispenserBlock;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
-import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.Enchantment.Rarity;
-import net.minecraft.enchantment.EnchantmentData;
-import net.minecraft.enchantment.EnchantmentType;
-import net.minecraft.enchantment.ProtectionEnchantment;
 import net.minecraft.entity.CreatureAttribute;
 import net.minecraft.inventory.EquipmentSlotType;
 import net.minecraft.inventory.container.ContainerType;
@@ -117,6 +115,11 @@ public class EnchModule {
 	static Configuration enchInfoConfig;
 
 	@SubscribeEvent
+	public void preInit(FMLConstructModEvent e) {
+		enchInfoConfig = new Configuration(new File(Apotheosis.configDir, "enchantments.cfg"));
+	}
+
+	@SubscribeEvent
 	public void init(FMLCommonSetupEvent e) {
 		this.reload(null);
 
@@ -138,11 +141,21 @@ public class EnchModule {
 		ItemStack msBrick = new ItemStack(Blocks.MOSSY_STONE_BRICKS);
 		Apotheosis.HELPER.addShaped(ApotheosisObjects.PRISMATIC_ALTAR, 3, 3, msBrick, null, msBrick, msBrick, Items.SEA_LANTERN, msBrick, msBrick, Blocks.ENCHANTING_TABLE, msBrick);
 		Apotheosis.HELPER.addShaped(new ItemStack(ApotheosisObjects.SCRAP_TOME, 8), 3, 3, book, book, book, book, Blocks.ANVIL, book, book, book, book);
-		Ingredient maxHellshelf = new EnchantmentIngredient(ApotheosisObjects.HELLSHELF, ApotheosisObjects.HELL_INFUSION, Math.min(3, getEnchInfo(ApotheosisObjects.HELL_INFUSION).getMaxLevel()));
+		Ingredient maxHellshelf;
+		if (ApotheosisObjects.HELL_INFUSION != null) {
+			maxHellshelf = new EnchantmentIngredient(ApotheosisObjects.HELLSHELF, ApotheosisObjects.HELL_INFUSION, Math.min(3, getEnchInfo(ApotheosisObjects.HELL_INFUSION).getMaxLevel()));
+		} else {
+			maxHellshelf = new EnchantmentIngredient(ApotheosisObjects.HELLSHELF, Enchantments.FIRE_ASPECT, Enchantments.FIRE_ASPECT.getMaxLevel());
+		}
 		Apotheosis.HELPER.addShaped(ApotheosisObjects.BLAZING_HELLSHELF, 3, 3, null, Items.FIRE_CHARGE, null, Items.FIRE_CHARGE, maxHellshelf, Items.FIRE_CHARGE, Items.BLAZE_POWDER, Items.BLAZE_POWDER, Items.BLAZE_POWDER);
 		Apotheosis.HELPER.addShaped(ApotheosisObjects.GLOWING_HELLSHELF, 3, 3, null, Blocks.GLOWSTONE, null, null, maxHellshelf, null, Blocks.GLOWSTONE, null, Blocks.GLOWSTONE);
 		Apotheosis.HELPER.addShaped(ApotheosisObjects.SEASHELF, 3, 3, Blocks.PRISMARINE_BRICKS, Blocks.PRISMARINE_BRICKS, Blocks.PRISMARINE_BRICKS, Apotheosis.potionIngredient(Potions.WATER), "forge:bookshelves", Items.PUFFERFISH, Blocks.PRISMARINE_BRICKS, Blocks.PRISMARINE_BRICKS, Blocks.PRISMARINE_BRICKS);
-		Ingredient maxSeashelf = new EnchantmentIngredient(ApotheosisObjects.SEASHELF, ApotheosisObjects.SEA_INFUSION, Math.min(3, getEnchInfo(ApotheosisObjects.SEA_INFUSION).getMaxLevel()));
+		Ingredient maxSeashelf;
+		if (ApotheosisObjects.SEA_INFUSION != null) {
+			maxSeashelf = new EnchantmentIngredient(ApotheosisObjects.SEASHELF, ApotheosisObjects.SEA_INFUSION, Math.min(3, getEnchInfo(ApotheosisObjects.SEA_INFUSION).getMaxLevel()));
+		} else {
+			maxSeashelf = new EnchantmentIngredient(ApotheosisObjects.SEASHELF, Enchantments.AQUA_AFFINITY, Enchantments.AQUA_AFFINITY.getMaxLevel());
+		}
 		Apotheosis.HELPER.addShaped(ApotheosisObjects.CRYSTAL_SEASHELF, 3, 3, null, Items.PRISMARINE_CRYSTALS, null, null, maxSeashelf, null, Items.PRISMARINE_CRYSTALS, null, Items.PRISMARINE_CRYSTALS);
 		Apotheosis.HELPER.addShaped(ApotheosisObjects.HEART_SEASHELF, 3, 3, null, Items.HEART_OF_THE_SEA, null, Items.PRISMARINE_SHARD, maxSeashelf, Items.PRISMARINE_SHARD, Items.PRISMARINE_SHARD, Items.PRISMARINE_SHARD, Items.PRISMARINE_SHARD);
 		Apotheosis.HELPER.addShaped(ApotheosisObjects.ENDSHELF, 3, 3, Blocks.END_STONE_BRICKS, Blocks.END_STONE_BRICKS, Blocks.END_STONE_BRICKS, Items.DRAGON_BREATH, "forge:bookshelves", Items.ENDER_PEARL, Blocks.END_STONE_BRICKS, Blocks.END_STONE_BRICKS, Blocks.END_STONE_BRICKS);
@@ -223,7 +236,7 @@ public class EnchModule {
 				new Block(AbstractBlock.Properties.create(Material.ROCK).hardnessAndResistance(1.5F).sound(SoundType.STONE)).setRegistryName("draconic_endshelf"),
 				new Block(AbstractBlock.Properties.create(Material.WOOD).hardnessAndResistance(1.5F).sound(SoundType.WOOD)).setRegistryName("beeshelf"),
 				new Block(AbstractBlock.Properties.create(Material.GOURD).hardnessAndResistance(1.5F).sound(SoundType.WOOD)).setRegistryName("melonshelf")
-				);
+		);
 		//Formatter::on
 		PlaceboUtil.registerOverride(new ApothEnchantBlock(), Apotheosis.MODID);
 	}
@@ -261,7 +274,7 @@ public class EnchModule {
 				new BlockItem(ApotheosisObjects.PEARL_ENDSHELF, new Item.Properties().group(Apotheosis.APOTH_GROUP)).setRegistryName("pearl_endshelf"),
 				new BlockItem(ApotheosisObjects.BEESHELF, new Item.Properties().group(Apotheosis.APOTH_GROUP)).setRegistryName("beeshelf"),
 				new BlockItem(ApotheosisObjects.MELONSHELF, new Item.Properties().group(Apotheosis.APOTH_GROUP)).setRegistryName("melonshelf")
-				);
+		);
 		//Formatter::on
 		DispenserBlock.registerDispenseBehavior(shears, DispenserBlock.DISPENSE_BEHAVIOR_REGISTRY.get(oldShears));
 	}
@@ -269,35 +282,33 @@ public class EnchModule {
 	@SubscribeEvent
 	public void enchants(Register<Enchantment> e) {
 		//Formatter::off
-		e.getRegistry().registerAll(
-				new HellInfusionEnchantment().setRegistryName(Apotheosis.MODID, "hell_infusion"),
-				new MinersFervorEnchant().setRegistryName(Apotheosis.MODID, "depth_miner"),
-				new StableFootingEnchant().setRegistryName(Apotheosis.MODID, "stable_footing"),
-				new ScavengerEnchant().setRegistryName(Apotheosis.MODID, "scavenger"),
-				new LifeMendingEnchant().setRegistryName(Apotheosis.MODID, "life_mending"),
-				new IcyThornsEnchant().setRegistryName(Apotheosis.MODID, "icy_thorns"),
-				new TemptingEnchant().setRegistryName(Apotheosis.MODID, "tempting"),
-				new ShieldBashEnchant().setRegistryName(Apotheosis.MODID, "shield_bash"),
-				new ReflectiveEnchant().setRegistryName(Apotheosis.MODID, "reflective"),
-				new BerserkersFuryEnchant().setRegistryName(Apotheosis.MODID, "berserk"),
-				new KnowledgeEnchant().setRegistryName(Apotheosis.MODID, "knowledge"),
-				new SplittingEnchant().setRegistryName(Apotheosis.MODID, "splitting"),
-				new NaturesBlessingEnchant().setRegistryName(Apotheosis.MODID, "natures_blessing"),
-				new ReboundingEnchant().setRegistryName(Apotheosis.MODID, "rebounding"),
-				new MagicProtEnchant().setRegistryName(Apotheosis.MODID, "magic_protection"),
-				new SeaInfusionEnchantment().setRegistryName("sea_infusion"),
-				new BaneEnchant(Rarity.UNCOMMON, CreatureAttribute.ARTHROPOD, EquipmentSlotType.MAINHAND).setRegistryName("minecraft", "bane_of_arthropods"),
-				new BaneEnchant(Rarity.UNCOMMON, CreatureAttribute.UNDEAD, EquipmentSlotType.MAINHAND).setRegistryName("minecraft", "smite"),
-				new BaneEnchant(Rarity.COMMON, CreatureAttribute.UNDEFINED, EquipmentSlotType.MAINHAND).setRegistryName("minecraft", "sharpness"),
-				new BaneEnchant(Rarity.UNCOMMON, CreatureAttribute.ILLAGER, EquipmentSlotType.MAINHAND).setRegistryName("bane_of_illagers"),
-				new DefenseEnchant(Rarity.COMMON, ProtectionEnchantment.Type.ALL, ARMOR).setRegistryName("minecraft", "protection"),
-				new DefenseEnchant(Rarity.UNCOMMON, ProtectionEnchantment.Type.ALL, ARMOR).setRegistryName("minecraft", "fire_protection"),
-				new DefenseEnchant(Rarity.RARE, ProtectionEnchantment.Type.ALL, ARMOR).setRegistryName("minecraft", "blast_protection"),
-				new DefenseEnchant(Rarity.UNCOMMON, ProtectionEnchantment.Type.ALL, ARMOR).setRegistryName("minecraft", "projectile_protection"),
-				new DefenseEnchant(Rarity.UNCOMMON, ProtectionEnchantment.Type.ALL, EquipmentSlotType.FEET).setRegistryName("minecraft", "feather_falling"),
-				new ObliterationEnchant().setRegistryName("obliteration"),
-				new CrescendoEnchant().setRegistryName("crescendo")
-				);
+		if (enchInfoConfig.getBoolean("Enabled", new ResourceLocation(Apotheosis.MODID, "hell_infusion").toString(), true, "Enable this enchantment")) e.getRegistry().register(new HellInfusionEnchantment().setRegistryName(Apotheosis.MODID, "hell_infusion"));
+		if (enchInfoConfig.getBoolean("Enabled", new ResourceLocation(Apotheosis.MODID, "depth_miner").toString(), true, "Enable this enchantment")) e.getRegistry().register(new MinersFervorEnchant().setRegistryName(Apotheosis.MODID, "depth_miner"));
+		if (enchInfoConfig.getBoolean("Enabled", new ResourceLocation(Apotheosis.MODID, "stable_footing").toString(), true, "Enable this enchantment")) e.getRegistry().register(new StableFootingEnchant().setRegistryName(Apotheosis.MODID, "stable_footing"));
+		if (enchInfoConfig.getBoolean("Enabled", new ResourceLocation(Apotheosis.MODID, "scavenger").toString(), true, "Enable this enchantment")) e.getRegistry().register(new ScavengerEnchant().setRegistryName(Apotheosis.MODID, "scavenger"));
+		if (enchInfoConfig.getBoolean("Enabled", new ResourceLocation(Apotheosis.MODID, "life_mending").toString(), true, "Enable this enchantment")) e.getRegistry().register(new LifeMendingEnchant().setRegistryName(Apotheosis.MODID, "life_mending"));
+		if (enchInfoConfig.getBoolean("Enabled", new ResourceLocation(Apotheosis.MODID, "icy_thorns").toString(), true, "Enable this enchantment")) e.getRegistry().register(new IcyThornsEnchant().setRegistryName(Apotheosis.MODID, "icy_thorns"));
+		if (enchInfoConfig.getBoolean("Enabled", new ResourceLocation(Apotheosis.MODID, "tempting").toString(), true, "Enable this enchantment")) e.getRegistry().register(new TemptingEnchant().setRegistryName(Apotheosis.MODID, "tempting"));
+		if (enchInfoConfig.getBoolean("Enabled", new ResourceLocation(Apotheosis.MODID, "shield_bash").toString(), true, "Enable this enchantment")) e.getRegistry().register(new ShieldBashEnchant().setRegistryName(Apotheosis.MODID, "shield_bash"));
+		if (enchInfoConfig.getBoolean("Enabled", new ResourceLocation(Apotheosis.MODID, "reflective").toString(), true, "Enable this enchantment")) e.getRegistry().register(new ReflectiveEnchant().setRegistryName(Apotheosis.MODID, "reflective"));
+		if (enchInfoConfig.getBoolean("Enabled", new ResourceLocation(Apotheosis.MODID, "berserk").toString(), true, "Enable this enchantment")) e.getRegistry().register(new BerserkersFuryEnchant().setRegistryName(Apotheosis.MODID, "berserk"));
+		if (enchInfoConfig.getBoolean("Enabled", new ResourceLocation(Apotheosis.MODID, "knowledge").toString(), true, "Enable this enchantment")) e.getRegistry().register(new KnowledgeEnchant().setRegistryName(Apotheosis.MODID, "knowledge"));
+		if (enchInfoConfig.getBoolean("Enabled", new ResourceLocation(Apotheosis.MODID, "splitting").toString(), true, "Enable this enchantment")) e.getRegistry().register(new SplittingEnchant().setRegistryName(Apotheosis.MODID, "splitting"));
+		if (enchInfoConfig.getBoolean("Enabled", new ResourceLocation(Apotheosis.MODID, "natures_blessing").toString(), true, "Enable this enchantment")) e.getRegistry().register(new NaturesBlessingEnchant().setRegistryName(Apotheosis.MODID, "natures_blessing"));
+		if (enchInfoConfig.getBoolean("Enabled", new ResourceLocation(Apotheosis.MODID, "rebounding").toString(), true, "Enable this enchantment")) e.getRegistry().register(new ReboundingEnchant().setRegistryName(Apotheosis.MODID, "rebounding"));
+		if (enchInfoConfig.getBoolean("Enabled", new ResourceLocation(Apotheosis.MODID, "magic_protection").toString(), true, "Enable this enchantment")) e.getRegistry().register(new MagicProtEnchant().setRegistryName(Apotheosis.MODID, "magic_protection"));
+		if (enchInfoConfig.getBoolean("Enabled", new ResourceLocation(Apotheosis.MODID, "sea_infusion").toString(), true, "Enable this enchantment")) e.getRegistry().register(new SeaInfusionEnchantment().setRegistryName("sea_infusion"));
+		if (enchInfoConfig.getBoolean("Enabled", new ResourceLocation(Apotheosis.MODID, "obliteration").toString(), true, "Enable this enchantment")) e.getRegistry().register(new ObliterationEnchant().setRegistryName("obliteration"));
+		if (enchInfoConfig.getBoolean("Enabled", new ResourceLocation(Apotheosis.MODID, "crescendo").toString(), true, "Enable this enchantment")) e.getRegistry().register(new CrescendoEnchant().setRegistryName("crescendo"));
+		if (enchInfoConfig.getBoolean("Enabled", new ResourceLocation(Apotheosis.MODID, "bane_of_illagers").toString(), true, "Enable this enchantment")) e.getRegistry().register(new BaneEnchant(Rarity.UNCOMMON, CreatureAttribute.ILLAGER, EquipmentSlotType.MAINHAND).setRegistryName("bane_of_illagers"));
+		e.getRegistry().register(new BaneEnchant(Rarity.UNCOMMON, CreatureAttribute.ARTHROPOD, EquipmentSlotType.MAINHAND).setRegistryName("minecraft", "bane_of_arthropods"));
+		e.getRegistry().register(new BaneEnchant(Rarity.UNCOMMON, CreatureAttribute.UNDEAD, EquipmentSlotType.MAINHAND).setRegistryName("minecraft", "smite"));
+		e.getRegistry().register(new BaneEnchant(Rarity.COMMON, CreatureAttribute.UNDEFINED, EquipmentSlotType.MAINHAND).setRegistryName("minecraft", "sharpness"));
+		e.getRegistry().register(new DefenseEnchant(Rarity.COMMON, ProtectionEnchantment.Type.ALL, ARMOR).setRegistryName("minecraft", "protection"));
+		e.getRegistry().register(new DefenseEnchant(Rarity.UNCOMMON, ProtectionEnchantment.Type.ALL, ARMOR).setRegistryName("minecraft", "fire_protection"));
+		e.getRegistry().register(new DefenseEnchant(Rarity.RARE, ProtectionEnchantment.Type.ALL, ARMOR).setRegistryName("minecraft", "blast_protection"));
+		e.getRegistry().register(new DefenseEnchant(Rarity.UNCOMMON, ProtectionEnchantment.Type.ALL, ARMOR).setRegistryName("minecraft", "projectile_protection"));
+		e.getRegistry().register(new DefenseEnchant(Rarity.UNCOMMON, ProtectionEnchantment.Type.ALL, EquipmentSlotType.FEET).setRegistryName("minecraft", "feather_falling"));
 		//Formatter::on
 	}
 

--- a/src/main/java/shadows/apotheosis/ench/EnchModuleEvents.java
+++ b/src/main/java/shadows/apotheosis/ench/EnchModuleEvents.java
@@ -39,6 +39,7 @@ import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import shadows.apotheosis.Apotheosis;
 import shadows.apotheosis.ApotheosisObjects;
 import shadows.apotheosis.ench.anvil.AnvilTile;
 import shadows.apotheosis.ench.objects.ScrappingTomeItem;
@@ -77,7 +78,7 @@ public class EnchModuleEvents {
 		}
 		if (e.getLeft().getItem() == ApotheosisObjects.HELLSHELF.asItem() || e.getLeft().getItem() == ApotheosisObjects.SEASHELF.asItem()) {
 			if (e.getLeft().getItem() != e.getRight().getItem() || e.getLeft().getCount() != 1) return;
-			Enchantment ench = e.getLeft().getItem() == ApotheosisObjects.HELLSHELF.asItem() ? ApotheosisObjects.HELL_INFUSION : ApotheosisObjects.SEA_INFUSION;
+			Enchantment ench = e.getLeft().getItem() == ApotheosisObjects.HELLSHELF.asItem() ? (ApotheosisObjects.HELL_INFUSION != null ? ApotheosisObjects.HELL_INFUSION : Enchantments.FIRE_ASPECT) : (ApotheosisObjects.SEA_INFUSION != null ? ApotheosisObjects.SEA_INFUSION : Enchantments.AQUA_AFFINITY);
 			int leftLvl = EnchantmentHelper.getEnchantmentLevel(ench, e.getLeft());
 			int rightLvl = EnchantmentHelper.getEnchantmentLevel(ench, e.getRight());
 			if (leftLvl == 0 || rightLvl != leftLvl) return;
@@ -104,14 +105,14 @@ public class EnchModuleEvents {
 		if (attacker instanceof PlayerEntity) {
 			PlayerEntity p = (PlayerEntity) attacker;
 			if (p.world.isRemote) return;
-			int scavenger = EnchantmentHelper.getEnchantmentLevel(ApotheosisObjects.SCAVENGER, p.getHeldItemMainhand());
+			int scavenger = ApotheosisObjects.SCAVENGER != null ? EnchantmentHelper.getEnchantmentLevel(ApotheosisObjects.SCAVENGER, p.getHeldItemMainhand()) : 0;
 			if (scavenger > 0 && p.world.rand.nextInt(100) < scavenger * 2.5F) {
 				if (this.dropLoot == null) {
 					this.dropLoot = ObfuscationReflectionHelper.findMethod(LivingEntity.class, "func_213354_a", DamageSource.class, boolean.class);
 				}
 				this.dropLoot.invoke(e.getEntityLiving(), e.getSource(), true);
 			}
-			int knowledge = EnchantmentHelper.getEnchantmentLevel(ApotheosisObjects.KNOWLEDGE, p.getHeldItemMainhand());
+			int knowledge = ApotheosisObjects.KNOWLEDGE != null ? EnchantmentHelper.getEnchantmentLevel(ApotheosisObjects.KNOWLEDGE, p.getHeldItemMainhand()) : 0;
 			if (knowledge > 0 && !(e.getEntity() instanceof PlayerEntity)) {
 				int items = 0;
 				for (ItemEntity i : e.getDrops())
@@ -139,7 +140,7 @@ public class EnchModuleEvents {
 		for (EquipmentSlotType slot : this.slots) {
 			ItemStack stack = e.getEntityLiving().getItemStackFromSlot(slot);
 			if (!stack.isEmpty() && stack.isDamaged()) {
-				int level = EnchantmentHelper.getEnchantmentLevel(ApotheosisObjects.LIFE_MENDING, stack);
+				int level = ApotheosisObjects.LIFE_MENDING != null ? EnchantmentHelper.getEnchantmentLevel(ApotheosisObjects.LIFE_MENDING, stack) : 0;
 				if (level > 0) {
 					int i = Math.min(level, stack.getDamage());
 					e.getEntityLiving().attackEntityFrom(EnchModule.CORRUPTED, i * 0.7F);
@@ -156,12 +157,12 @@ public class EnchModuleEvents {
 	@SubscribeEvent
 	public void breakSpeed(PlayerEvent.BreakSpeed e) {
 		PlayerEntity p = e.getPlayer();
-		if (!p.isOnGround() && EnchantmentHelper.getMaxEnchantmentLevel(ApotheosisObjects.STABLE_FOOTING, p) > 0) {
+		if (!p.isOnGround() && ApotheosisObjects.STABLE_FOOTING != null && EnchantmentHelper.getMaxEnchantmentLevel(ApotheosisObjects.STABLE_FOOTING, p) > 0) {
 			if (e.getOriginalSpeed() < e.getNewSpeed() * 5) e.setNewSpeed(e.getNewSpeed() * 5F);
 		}
 		ItemStack stack = p.getHeldItemMainhand();
 		if (stack.isEmpty()) return;
-		int depth = EnchantmentHelper.getEnchantmentLevel(ApotheosisObjects.DEPTH_MINER, stack);
+		int depth = ApotheosisObjects.DEPTH_MINER != null ? EnchantmentHelper.getEnchantmentLevel(ApotheosisObjects.DEPTH_MINER, stack) : 0;
 		if (depth > 0) {
 			if (stack.getDestroySpeed(e.getState()) > 1.0F) {
 				float hardness = e.getState().getBlockHardness(e.getPlayer().world, e.getPos());
@@ -176,7 +177,7 @@ public class EnchModuleEvents {
 	@SubscribeEvent
 	public void rightClick(PlayerInteractEvent.RightClickBlock e) {
 		ItemStack s = e.getItemStack();
-		int nbLevel = EnchantmentHelper.getEnchantmentLevel(ApotheosisObjects.NATURES_BLESSING, s);
+		int nbLevel = ApotheosisObjects.NATURES_BLESSING != null ? EnchantmentHelper.getEnchantmentLevel(ApotheosisObjects.NATURES_BLESSING, s) : 0;
 		if (!e.getEntity().isSneaking() && nbLevel > 0 && BoneMealItem.applyBonemeal(s.copy(), e.getWorld(), e.getPos(), e.getPlayer())) {
 			s.damageItem(6 - nbLevel, e.getPlayer(), ent -> ent.sendBreakAnimation(e.getHand()));
 			e.setCanceled(true);
@@ -203,7 +204,7 @@ public class EnchModuleEvents {
 	public void livingHurt(LivingHurtEvent e) {
 		LivingEntity user = e.getEntityLiving();
 		if (e.getSource().getTrueSource() instanceof Entity && user.getActivePotionEffect(Effects.RESISTANCE) == null) {
-			int level = EnchantmentHelper.getMaxEnchantmentLevel(ApotheosisObjects.BERSERK, user);
+			int level = ApotheosisObjects.BERSERK != null ? EnchantmentHelper.getMaxEnchantmentLevel(ApotheosisObjects.BERSERK, user) : 0;
 			if (level > 0) {
 				user.hurtResistantTime = 0;
 				user.attackEntityFrom(EnchModule.CORRUPTED, level * level);
@@ -214,7 +215,7 @@ public class EnchModuleEvents {
 		}
 		if (e.getSource().isMagicDamage() && e.getSource().getTrueSource() instanceof LivingEntity) {
 			LivingEntity src = (LivingEntity) e.getSource().getTrueSource();
-			int lvl = EnchantmentHelper.getMaxEnchantmentLevel(ApotheosisObjects.MAGIC_PROTECTION, src);
+			int lvl = ApotheosisObjects.MAGIC_PROTECTION != null ? EnchantmentHelper.getMaxEnchantmentLevel(ApotheosisObjects.MAGIC_PROTECTION, src) : 0;
 			if (lvl > 0) {
 				//TODO: FIXME should only be reducing damage by the value of OA, this will use all active protection enchantments.
 				e.setAmount(CombatRules.getDamageAfterMagicAbsorb(e.getAmount(), EnchantmentHelper.getEnchantmentModifierDamage(src.getArmorInventoryList(), e.getSource())));

--- a/src/main/java/shadows/apotheosis/ench/objects/HellshelfItem.java
+++ b/src/main/java/shadows/apotheosis/ench/objects/HellshelfItem.java
@@ -2,6 +2,7 @@ package shadows.apotheosis.ench.objects;
 
 import net.minecraft.block.Block;
 import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.Enchantments;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroup;
@@ -20,7 +21,7 @@ public class HellshelfItem extends BlockItem {
 
 	@Override
 	public boolean canApplyAtEnchantingTable(ItemStack stack, Enchantment enchantment) {
-		return !stack.isEnchanted() && stack.getCount() == 1 && enchantment == ApotheosisObjects.HELL_INFUSION;
+		return !stack.isEnchanted() && stack.getCount() == 1 && enchantment == (ApotheosisObjects.HELL_INFUSION != null ? ApotheosisObjects.HELL_INFUSION : Enchantments.FIRE_ASPECT);
 	}
 
 	@Override

--- a/src/main/java/shadows/apotheosis/ench/objects/SeashelfItem.java
+++ b/src/main/java/shadows/apotheosis/ench/objects/SeashelfItem.java
@@ -2,6 +2,7 @@ package shadows.apotheosis.ench.objects;
 
 import net.minecraft.block.Block;
 import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.Enchantments;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroup;
@@ -20,7 +21,7 @@ public class SeashelfItem extends BlockItem {
 
 	@Override
 	public boolean canApplyAtEnchantingTable(ItemStack stack, Enchantment enchantment) {
-		return !stack.isEnchanted() && stack.getCount() == 1 && enchantment == ApotheosisObjects.SEA_INFUSION;
+		return !stack.isEnchanted() && stack.getCount() == 1 && enchantment == (ApotheosisObjects.SEA_INFUSION != null ? ApotheosisObjects.SEA_INFUSION : Enchantments.AQUA_AFFINITY);
 	}
 
 	@Override


### PR DESCRIPTION
Addresses #411 

In cases where Hell/Sea Infusion are disabled Hellshelves & Seashelves will use Fire Aspect/Aqua Affinity respectively for upgrading 

Only effects enchants module enchantments

I'm not married to how any of this has been done feel free to completely redo it I just didn't want to be that lazy guy saying "add this please" and not doing any work.