### PR TITLE
Revert block on potion charm repairability

### DIFF
--- a/src/main/java/shadows/apotheosis/potion/PotionCharmItem.java
+++ b/src/main/java/shadows/apotheosis/potion/PotionCharmItem.java
@@ -33,7 +33,7 @@ import shadows.apotheosis.Apotheosis;
 public class PotionCharmItem extends Item {
 
 	public PotionCharmItem() {
-		super(new Item.Properties().stacksTo(1).durability(192).tab(Apotheosis.APOTH_GROUP).setNoRepair());
+		super(new Item.Properties().stacksTo(1).durability(192).tab(Apotheosis.APOTH_GROUP));
 	}
 
 	@Override


### PR DESCRIPTION
Reverting the block on repairing potion charms

Fixes: #493 

Regardless if the previous "logic" was "not supported" it has been this way for a long time, there is no reason to intentionally make things more difficult without a configuration option to let the user decide.