### PR TITLE
Fixed tooltip element scale bug.

### DIFF
--- a/src/main/java/shadows/apotheosis/adventure/client/SocketTooltipRenderer.java
+++ b/src/main/java/shadows/apotheosis/adventure/client/SocketTooltipRenderer.java
@@ -65,6 +65,7 @@ public class SocketTooltipRenderer implements ClientTooltipComponent {
 				mvStack.scale(0.5F, 0.5F, 1);
 				itemRenderer.renderAndDecorateFakeItem(gem, 2 * x + 1, 2 * y + 1);
 				mvStack.popPose();
+				RenderSystem.applyModelViewMatrix();
 			}
 			y += this.spacing;
 		}


### PR DESCRIPTION
This PR fixes a bug some users are experiencing where tooltip elements from other mods are rendered in the wrong position and at the wrong scale when viewing equipment with at least one filled socket.
This was brought to my attention in this issue: https://github.com/AHilyard/LegendaryTooltips/issues/38