### PR TITLE
Add infusion recipe for endrem's cryptic_eye

### DIFF
--- a/src/main/resources/data/apotheosis/recipes/enchanting/cryptic_eye.json
+++ b/src/main/resources/data/apotheosis/recipes/enchanting/cryptic_eye.json
@@ -1,0 +1,31 @@
+{
+	"type": "apotheosis:enchanting",
+	"conditions": [
+		{
+			"type": "apotheosis:module",
+			"module": "enchantment"
+		},
+		{
+			"type": "forge:mod_loaded",
+			"modid": "endrem"
+		}
+	],
+	"input": {
+		"item": "minecraft:ender_eye"
+	},
+	"requirements": {
+		"eterna": 30,
+		"quanta": 100,
+		"arcana": 100
+	},
+	"max_requirements": {
+		"eterna": -1,
+		"quanta": -1,
+		"arcana": -1
+	},
+	"display_level": 3,
+	"result": {
+		"item": "endrem:cryptic_eye",
+		"count": 1
+	}
+}


### PR DESCRIPTION
Ran into this [issue](https://github.com/Team-Remastered/End-Remastered-Forge/issues/33) on my world. Because of the way Apotheosis overhauls enchanting the enchant event is never called in endrem ([here](https://github.com/Team-Remastered/End-Remastered-Forge/blob/1.18.2/src/main/java/com/teamremastered/endrem/mixin/PlayerEnchantMixin.java)). 

Taking advice from one of the comments, creating a late-middle-game infusion enchanting recipe seems wisest. Using only top-tier overworld and nether enchanting shelves to get the highest obtainable enchanting values seems to be most in line with the feel of endrem.

The only issue I see with this approach is that endrem provides a config option to disable obtaining the cryptic eye. I don't believe this implementation would respect that config option (and seeing as I just started getting into modding, I'm unaware of an unintrusive method to consider that config option). 

Tested on two test worlds, one with both apotheosis and endrem (recipe available in JEI and obtainable), and another with only apotheosis (recipe not available and the cryptic eye is not obtainable). 