### PR TITLE
Changed all vanilla boss sizes to be correct

### DIFF
--- a/src/main/resources/data/apotheosis/bosses/overworld/husk.json
+++ b/src/main/resources/data/apotheosis/bosses/overworld/husk.json
@@ -3,8 +3,8 @@
 	"weight": 75,
 	"quality": 2,
 	"size": {
-		"width": 1,
-		"height": 2
+		"width": 0.6,
+		"height": 1.95
 	},
 	"valid_gear_sets": [
 		"#overworld"

--- a/src/main/resources/data/apotheosis/bosses/overworld/skeleton.json
+++ b/src/main/resources/data/apotheosis/bosses/overworld/skeleton.json
@@ -3,8 +3,8 @@
 	"weight": 100,
 	"quality": 0,
 	"size": {
-		"width": 1,
-		"height": 2
+		"width": 0.6,
+		"height": 1.99
 	},
 	"valid_gear_sets": [
 		"#overworld_bow"

--- a/src/main/resources/data/apotheosis/bosses/overworld/stray.json
+++ b/src/main/resources/data/apotheosis/bosses/overworld/stray.json
@@ -3,8 +3,8 @@
 	"weight": 75,
 	"quality": 2,
 	"size": {
-		"width": 1,
-		"height": 2
+		"width": 0.6,
+		"height": 1.99
 	},
 	"valid_gear_sets": [
 		"#overworld_bow"

--- a/src/main/resources/data/apotheosis/bosses/overworld/vindicator.json
+++ b/src/main/resources/data/apotheosis/bosses/overworld/vindicator.json
@@ -3,8 +3,8 @@
 	"weight": 45,
 	"quality": 4,
 	"size": {
-		"width": 1,
-		"height": 2
+		"width": 0.6,
+		"height": 1.95
 	},
 	"valid_gear_sets": [
 		"#overworld"

--- a/src/main/resources/data/apotheosis/bosses/overworld/witch.json
+++ b/src/main/resources/data/apotheosis/bosses/overworld/witch.json
@@ -3,8 +3,8 @@
 	"weight": 45,
 	"quality": 4,
 	"size": {
-		"width": 1,
-		"height": 2
+		"width": 0.6,
+		"height": 1.95
 	},
 	"valid_gear_sets": [
 		"#overworld"

--- a/src/main/resources/data/apotheosis/bosses/overworld/zombie.json
+++ b/src/main/resources/data/apotheosis/bosses/overworld/zombie.json
@@ -3,8 +3,8 @@
 	"weight": 100,
 	"quality": 0,
 	"size": {
-		"width": 1,
-		"height": 2
+		"width": 0.6,
+		"height": 1.95
 	},
 	"valid_gear_sets": [
 		"#overworld"

--- a/src/main/resources/data/apotheosis/bosses/the_end/enderman.json
+++ b/src/main/resources/data/apotheosis/bosses/the_end/enderman.json
@@ -2,8 +2,8 @@
 	"entity": "minecraft:enderman",
 	"weight": 80,
 	"size": {
-		"width": 1,
-		"height": 3
+		"width": 0.6,
+		"height": 2.9
 	},
 	"valid_gear_sets": [
 		"#the_end"

--- a/src/main/resources/data/apotheosis/bosses/the_end/endermite.json
+++ b/src/main/resources/data/apotheosis/bosses/the_end/endermite.json
@@ -3,8 +3,8 @@
 	"weight": 5,
 	"quality": 1,
 	"size": {
-		"width": 1,
-		"height": 3
+		"width": 0.4,
+		"height": 0.3
 	},
 	"valid_gear_sets": [
 		"#the_end"

--- a/src/main/resources/data/apotheosis/bosses/the_end/evoker.json
+++ b/src/main/resources/data/apotheosis/bosses/the_end/evoker.json
@@ -3,8 +3,8 @@
 	"weight": 20,
 	"quality": 3,
 	"size": {
-		"width": 1,
-		"height": 2
+		"width": 0.6,
+		"height": 1.95
 	},
 	"valid_gear_sets": [
 		"#the_end"

--- a/src/main/resources/data/apotheosis/bosses/the_end/phantom.json
+++ b/src/main/resources/data/apotheosis/bosses/the_end/phantom.json
@@ -3,8 +3,8 @@
 	"weight": 50,
 	"quality": 0,
 	"size": {
-		"width": 2.5,
-		"height": 1
+		"width": 0.9,
+		"height": 0.5
 	},
 	"valid_gear_sets": [
 		"#the_end"

--- a/src/main/resources/data/apotheosis/bosses/the_nether/blaze.json
+++ b/src/main/resources/data/apotheosis/bosses/the_nether/blaze.json
@@ -3,8 +3,8 @@
 	"weight": 30,
 	"quality": 7,
 	"size": {
-		"width": 1.6,
-		"height": 1.6
+		"width": 0.6,
+		"height": 1.8
 	},
 	"valid_gear_sets": [
 		"#the_nether"

--- a/src/main/resources/data/apotheosis/bosses/the_nether/piglin.json
+++ b/src/main/resources/data/apotheosis/bosses/the_nether/piglin.json
@@ -3,8 +3,8 @@
 	"weight": 70,
 	"quality": 2,
 	"size": {
-		"width": 1,
-		"height": 2
+		"width": 0.6,
+		"height": 1.95
 	},
 	"valid_gear_sets": [
 		"#the_nether"

--- a/src/main/resources/data/apotheosis/bosses/the_nether/piglin_brute.json
+++ b/src/main/resources/data/apotheosis/bosses/the_nether/piglin_brute.json
@@ -3,8 +3,8 @@
 	"weight": 50,
 	"quality": 4,
 	"size": {
-		"width": 1,
-		"height": 2
+		"width": 0.6,
+		"height": 1.95
 	},
 	"valid_gear_sets": [
 		"#the_nether"

--- a/src/main/resources/data/apotheosis/bosses/the_nether/wither_skeleton.json
+++ b/src/main/resources/data/apotheosis/bosses/the_nether/wither_skeleton.json
@@ -3,8 +3,8 @@
 	"weight": 100,
 	"quality": 0,
 	"size": {
-		"width": 1,
-		"height": 2
+		"width": 0.7,
+		"height": 2.4
 	},
 	"valid_gear_sets": [
 		"#the_nether",

--- a/src/main/resources/data/apotheosis/bosses/the_nether/zoglin.json
+++ b/src/main/resources/data/apotheosis/bosses/the_nether/zoglin.json
@@ -3,8 +3,8 @@
 	"weight": 30,
 	"quality": 7,
 	"size": {
-		"width": 1.6,
-		"height": 1.6
+		"width": 1.3965,
+		"height": 1.4
 	},
 	"valid_gear_sets": [
 		"#the_nether"

--- a/src/main/resources/data/apotheosis/bosses/the_nether/zombified_piglin.json
+++ b/src/main/resources/data/apotheosis/bosses/the_nether/zombified_piglin.json
@@ -2,8 +2,8 @@
 	"entity": "minecraft:zombified_piglin",
 	"weight": 100,
 	"size": {
-		"width": 1,
-		"height": 2
+		"width": 0.6,
+		"height": 1.95
 	},
 	"valid_gear_sets": [
 		"#the_nether"


### PR DESCRIPTION
Fixes issue #1015

Updates vanilla boss mob width and height to be accurate to sizes stated on the [Minecraft wiki](https://minecraft.wiki/w/Mob#List_of_mobs).