### PR TITLE
Fix Extraction Vial

### DIFF
--- a/src/main/java/dev/shadowsoffire/apotheosis/adventure/affix/socket/ExtractionRecipe.java
+++ b/src/main/java/dev/shadowsoffire/apotheosis/adventure/affix/socket/ExtractionRecipe.java
@@ -31,8 +31,8 @@ public class ExtractionRecipe extends ApothSmithingRecipe implements ReactiveSmi
      */
     @Override
     public boolean matches(Container pInv, Level pLevel) {
-        List<ItemStack> sockets = SocketHelper.getGems(pInv.getItem(0));
-        return pInv.getItem(ADDITION).getItem() == Items.VIAL_OF_EXTRACTION.get() && !sockets.isEmpty() && !sockets.get(BASE).isEmpty();
+        List<ItemStack> sockets = SocketHelper.getGems(pInv.getItem(BASE));
+        return pInv.getItem(ADDITION).getItem() == Items.VIAL_OF_EXTRACTION.get() && !sockets.isEmpty() && !sockets.get(0).isEmpty();
     }
 
     /**
@@ -41,7 +41,7 @@ public class ExtractionRecipe extends ApothSmithingRecipe implements ReactiveSmi
     @Override
     public ItemStack assemble(Container pInv, RegistryAccess regs) {
         ItemStack out = pInv.getItem(BASE);
-        return SocketHelper.getGems(out).get(BASE);
+        return SocketHelper.getGems(out).get(0);
     }
 
     @Override


### PR DESCRIPTION
Fixed the Vial of Extraction not working at all. It seems the new template slot addition to the smithing table(in MC 1.20) was only partially implemented here. I believe to have fixed the issue through my limited testing(it works in a client/singleplay env). Let me know if you see any issues here.