### PR TITLE
Fix for potential softlock

### DIFF
--- a/src/main/java/dev/shadowsoffire/apotheosis/adventure/compat/GatewaysCompat.java
+++ b/src/main/java/dev/shadowsoffire/apotheosis/adventure/compat/GatewaysCompat.java
@@ -98,11 +98,11 @@ public class GatewaysCompat {
         @Override
         public void generateLoot(ServerLevel level, GatewayEntity gate, Player summoner, Consumer<ItemStack> list) {
             AffixLootEntry entry = AffixLootRegistry.INSTANCE.getRandomItem(level.random, summoner.getLuck(), IDimensional.matches(level), IStaged.matches(summoner));
-            if (entry == null) {
+            try {
+                list.accept(LootController.createLootItem(entry.getStack(), this.rarity.get(), level.random));
+            }catch(NullPointerException e){
                 AdventureModule.LOGGER.error("Failed to find an affix loot item for a RarityAffixItemReward executing in dimension {} with rarity {}.", level.dimension(), rarity.getId());
-                return;
             }
-            list.accept(LootController.createLootItem(entry.getStack(), this.rarity.get(), level.random));
         }
 
         @Override


### PR DESCRIPTION
There's an error with GatewaysCompat where if entry.getStack() returns a null value the game will become softlocked and crash on world join. Some variation of the following will fix the issue and cause it to properly generate a log event instead of infinitely crashing.  