### PR TITLE
Update rarity_materials.json

### DIFF
--- a/src/main/resources/data/apotheosis/tags/items/rarity_materials.json
+++ b/src/main/resources/data/apotheosis/tags/items/rarity_materials.json
@@ -1,10 +1,10 @@
 {
 	"values": [
-		"apotheosis:common_material",
-		"apotheosis:uncommon_material",
-		"apotheosis:rare_material",
-		"apotheosis:epic_material",
-		"apotheosis:mythic_material",
-		"apotheosis:ancient_material"
+		{"id": "apotheosis:common_material", "required": false},
+		{"id": "apotheosis:uncommon_material", "required": false},
+		{"id": "apotheosis:rare_material", "required": false},
+		{"id": "apotheosis:epic_material", "required": false},
+		{"id": "apotheosis:mythic_material", "required": false},
+		{"id": "apotheosis:ancient_material", "required": false}
 	]
 }


### PR DESCRIPTION
Prevents "cooked" tag when adventure module is disabled + good practice.

Even though the tag may become useless without the adventure module, mods like "Load My F****** Tags" will detect that the tag is "cooked."

If other Apotheosis tags are affected by modules being disabled, they should be edited in the same manner as the edit provided in this pull request.