### PR TITLE
Add a Config Option to announce exact Spawn Position of Bosses

### DIFF
--- a/src/main/java/dev/shadowsoffire/apotheosis/AdventureConfig.java
+++ b/src/main/java/dev/shadowsoffire/apotheosis/AdventureConfig.java
@@ -33,6 +33,7 @@ public class AdventureConfig {
     public static boolean curseBossItems = false;
     public static float bossAnnounceRange = NaturalSpawner.SPAWN_DISTANCE_BLOCK + 12;
     public static float bossAnnounceVolume = 0.75F;
+    public static boolean bossAnnounceExact = false;
     public static int bossSpawnCooldown = 3600;
     public static boolean bossAutoAggro = false;
     public static boolean bossGlowOnSpawn = true;
@@ -91,6 +92,7 @@ public class AdventureConfig {
         bossAnnounceRange = c.getFloat("Boss Announcement Range", "bosses", bossAnnounceRange, 0, 1024,
             "The range at which boss spawns will be announced.  If you are closer than this number of blocks (ignoring y-level), you will receive the announcement.\nServer-authoritative.");
         bossAnnounceVolume = c.getFloat("Boss Announce Volume", "bosses", bossAnnounceVolume, 0, 1, "The volume of the boss announcement sound. 0 to disable.\nClientside.");
+        bossAnnounceExact = c.getBoolean("Boss Announce Position", "bosses", bossAnnounceExact, "If true, boss announcements will always include the exact spawn position.\nServer-authoritative.");
         bossSpawnCooldown = c.getInt("Boss Spawn Cooldown", "bosses", bossSpawnCooldown, 0, 720000, "The time, in ticks, that must pass between any two natural boss spawns in a single dimension.\nServer-authoritative.");
         bossAutoAggro = c.getBoolean("Boss Auto-Aggro", "bosses", bossAutoAggro, "If true, invading bosses will automatically target the closest player.\nServer-authoritative.");
         bossGlowOnSpawn = c.getBoolean("Boss Glowing On Spawn", "bosses", bossGlowOnSpawn, "If true, bosses will glow when they spawn.\nServer-authoritative.");

--- a/src/main/java/dev/shadowsoffire/apotheosis/mobs/ApothMobEvents.java
+++ b/src/main/java/dev/shadowsoffire/apotheosis/mobs/ApothMobEvents.java
@@ -162,7 +162,11 @@ public class ApothMobEvents {
                     sLevel.players().forEach(p -> {
                         Vec3 tPos = new Vec3(boss.getX(), p.getY(), boss.getZ());
                         if (p.distanceToSqr(tPos) <= AdventureConfig.bossAnnounceRange * AdventureConfig.bossAnnounceRange) {
-                            ((ServerPlayer) p).connection.send(new ClientboundSetActionBarTextPacket(Component.translatable("info.apotheosis.boss_spawn", name, (int) boss.getX(), (int) boss.getY())));
+                            Component message = AdventureConfig.bossAnnounceExact ?
+                                    Component.translatable("info.apotheosis.boss_spawn_exact", name, (int) boss.getX(), (int) boss.getY(), (int) boss.getZ()) :
+                                    Component.translatable("info.apotheosis.boss_spawn", name);
+
+                            ((ServerPlayer) p).connection.send(new ClientboundSetActionBarTextPacket(message));
                             TextColor color = name.getStyle().getColor();
                             PacketDistributor.sendToPlayer((ServerPlayer) player, new BossSpawnPayload(boss.blockPosition(), color == null ? 0xFFFFFF : color.getValue()));
                         }

--- a/src/main/resources/assets/apotheosis/lang/en_us.json
+++ b/src/main/resources/assets/apotheosis/lang/en_us.json
@@ -683,6 +683,7 @@
     "loot_category.apotheosis.boots.plural": "Boots",
 
     "info.apotheosis.boss_spawn": "%s has awoken nearby!",
+    "info.apotheosis.boss_spawn_exact": "%s has awoken at %d, %d, %d!",
     "info.apotheosis.boss": "%s Apothic Boss",
     "info.apotheosis.boss_item": "Will Drop: %s",
     "info.apotheosis.boss_modifiers": "Boss Modifiers:",


### PR DESCRIPTION
Notes:
- Somehow the config option inserted itself at the bottom of the `bosses` category, despite me having it in the middle..?
- Not sure on color regarding `info.apotheosis.boss_spawn_exact`, I wasn't able to get an implementation I was happy with/that didn't look horrible to read code-wise. Perhaps a different format instead of `%d, %d, %d` would allow it to stay white?
- `info.apotheosis.boss_spawn_exact` is not included in other lang files yet.