### PR TITLE
Fix #1617: Resolve piping Sigils of Enhancement into the Augmentation Table

### DIFF
--- a/src/main/java/dev/shadowsoffire/apotheosis/Apotheosis.java
+++ b/src/main/java/dev/shadowsoffire/apotheosis/Apotheosis.java
@@ -173,6 +173,7 @@ public class Apotheosis {
     public void caps(RegisterCapabilitiesEvent e) {
         e.registerBlockEntity(Capabilities.ItemHandler.BLOCK, Apoth.Tiles.SALVAGING_TABLE, (be, side) -> be.getItemHandler());
         e.registerBlockEntity(Capabilities.ItemHandler.BLOCK, Apoth.Tiles.REFORGING_TABLE, (be, side) -> be.getInventory());
+        e.registerBlockEntity(Capabilities.ItemHandler.BLOCK, Apoth.Tiles.AUGMENTING_TABLE, (be, side) -> be.getInventory());
     }
 
     @SubscribeEvent


### PR DESCRIPTION
Allow hoppers and other pipes to input Sigils of Enhancement into the Augmentation Table.