### PR TITLE
Fix gems' tooltip translation key missing, fix #1674

### DIFF
--- a/src/main/resources/assets/apotheosis/lang/en_us.json
+++ b/src/main/resources/assets/apotheosis/lang/en_us.json
@@ -681,6 +681,8 @@
     "loot_category.apotheosis.leggings.plural": "Leggings",
     "loot_category.apotheosis.boots": "Boots",
     "loot_category.apotheosis.boots.plural": "Boots",
+    "loot_category.apotheosis.shears": "Shears",
+    "loot_category.apotheosis.shears.plural": "Shears",
 
     "info.apotheosis.boss_spawn": "%s has awoken nearby!",
     "info.apotheosis.boss": "%s Apothic Boss",

--- a/src/main/resources/assets/apotheosis/lang/en_us.json
+++ b/src/main/resources/assets/apotheosis/lang/en_us.json
@@ -723,7 +723,7 @@
     "reward.apotheosis.gem": "Apothic Gem (%s)",
     "reward.apotheosis.random_gem": "Apothic Gem (Random)",
     "reward.apotheosis.true_random_gem": "Truly Random Apothic Gem",
-    "reward.apotheosis.netherite_smithing_template": "Netherite Smiting Template",
+    "reward.apotheosis.netherite_smithing_template": "Netherite Smithing Template",
     "error.apotheosis.gate_tier_incorrect": "This Gateway can only be opened in World Tier: %s",
     "modifier.apotheosis.affix": "Receives an Affix Item",
     "tooltip.apotheosis.requires_world_tier": "Requires World Tier: %s",

--- a/src/main/resources/assets/apotheosis/lang/zh_cn.json
+++ b/src/main/resources/assets/apotheosis/lang/zh_cn.json
@@ -134,9 +134,6 @@
     "affix.apotheosis:breaker/attribute/experienced": "经验",
     "affix.apotheosis:breaker/attribute/experienced.suffix": "学者",
 
-    "affix.apotheosis:melee/attribute/elongated": "延展",
-    "affix.apotheosis:melee/attribute/elongated.suffix": "远战",
-
     "affix.apotheosis:ranged/attribute/agile": "敏捷",
     "affix.apotheosis:ranged/attribute/agile.suffix": "迅敏",
 
@@ -515,7 +512,6 @@
     "misc.apotheosis.level.many": "级",
     "name.apotheosis.treasure_goblin": "宝藏哥布林",
 
-    "item.apotheosis.gem.apotheosis:legacy": "经典宝石",
     "item.apotheosis.gem.apotheosis:core/guardian": "护卫宝石",
     "item.apotheosis.gem.apotheosis:core/ballast": "稳定宝石",
     "item.apotheosis.gem.apotheosis:core/solar": "阳炎宝石",
@@ -685,6 +681,8 @@
     "loot_category.apotheosis.leggings.plural": "护腿",
     "loot_category.apotheosis.boots": "靴子",
     "loot_category.apotheosis.boots.plural": "靴子",
+    "loot_category.apotheosis.shears": "剪刀",
+    "loot_category.apotheosis.shears.plural": "剪刀",
 
     "info.apotheosis.boss_spawn": "%s在附近苏醒了！",
     "info.apotheosis.boss": "神化Boss（%s）",

--- a/src/main/resources/assets/apotheosis/lang/zh_cn.json
+++ b/src/main/resources/assets/apotheosis/lang/zh_cn.json
@@ -525,7 +525,7 @@
     "item.apotheosis.gem.apotheosis:core/slipstream": "逸流宝石",
     "item.apotheosis.gem.apotheosis:core/brawlers": "斗争宝石",
     "item.apotheosis.gem.apotheosis:core/combatant": "战斗宝石",
-    "item.apotheosis.gem.apotheosis:overworld/earth": "地球宝石",
+    "item.apotheosis.gem.apotheosis:overworld/earth": "大地宝石",
     "item.apotheosis.gem.apotheosis:overworld/royalty": "王室宝石",
     "item.apotheosis.gem.apotheosis:overworld/verdant_ruin": "翠殒宝石",
     "item.apotheosis.gem.apotheosis:the_nether/inferno": "炽狱宝石",

--- a/src/main/resources/assets/apotheosis/lang/zh_cn.json
+++ b/src/main/resources/assets/apotheosis/lang/zh_cn.json
@@ -472,7 +472,7 @@
     "gem_class.melee_weapon": "近战武器",
     "gem_class.ranged_weapon": "远程武器",
     "gem_class.light_weapon": "轻型武器",
-    "gem_class.core_armor": "核心盔甲",
+    "gem_class.core_armor": "主体盔甲",
     "gem_class.lower_armor": "下身盔甲",
     "gem_class.armor": "盔甲",
     "gem_class.breaker": "挖掘工具",

--- a/src/main/resources/assets/apotheosis/patchouli_books/apoth_chronicle/zh_cn/entries/enchanting/enchantments/earths_boon.json
+++ b/src/main/resources/assets/apotheosis/patchouli_books/apoth_chronicle/zh_cn/entries/enchanting/enchantments/earths_boon.json
@@ -1,5 +1,5 @@
 {
-    "name": "地球恩惠",
+    "name": "大地恩惠",
     "icon": "minecraft:enchanted_book",
     "category": "apotheosis:enchanting/enchantments",
 	"flag": "apotheosis:enchanting",
@@ -7,7 +7,7 @@
     "pages": [
         {
             "type": "patchouli:text",
-            "text": "$(2)地球恩惠$()是镐的极品魔咒。$(p)挖掘简单的石头时，有机会掉落一个矿石方块。"
+            "text": "$(2)大地恩惠$()是镐的极品魔咒。$(p)挖掘简单的石头时，有机会掉落一个矿石方块。"
         }
 	]
 }

--- a/src/main/resources/assets/apotheosis/patchouli_books/apoth_chronicle/zh_cn/entries/enchanting/enchantments/knowledge.json
+++ b/src/main/resources/assets/apotheosis/patchouli_books/apoth_chronicle/zh_cn/entries/enchanting/enchantments/knowledge.json
@@ -1,5 +1,5 @@
 {
-    "name": "岁月学识",
+    "name": "亘古智慧",
     "icon": "minecraft:enchanted_book",
     "category": "apotheosis:enchanting/enchantments",
 	"flag": "apotheosis:enchanting",
@@ -7,7 +7,7 @@
     "pages": [
         {
             "type": "patchouli:text",
-            "text": "$(2)岁月学识$()是一个极品魔咒，可以应用于剑。$(p)当你杀死一个生物时，所有的掉落物都会转化为经验。$(p)每个单独的物品都价值相同的经验。"
+            "text": "$(2)亘古智慧$()是一个极品魔咒，可以应用于剑。$(p)当你杀死一个生物时，所有的掉落物都会转化为经验。$(p)每个单独的物品都价值相同的经验。"
         },
 		{
 			"type": "patchouli:text",

--- a/src/main/resources/assets/apotheosis/patchouli_books/apoth_chronicle/zh_cn/entries/enchanting/enchantments/reflective.json
+++ b/src/main/resources/assets/apotheosis/patchouli_books/apoth_chronicle/zh_cn/entries/enchanting/enchantments/reflective.json
@@ -1,5 +1,5 @@
 {
-    "name": "防御反击",
+    "name": "盾反",
     "icon": "minecraft:enchanted_book",
     "category": "apotheosis:enchanting/enchantments",
 	"flag": "apotheosis:enchanting",
@@ -7,11 +7,11 @@
     "pages": [
         {
             "type": "patchouli:text",
-            "text": "$(9)防御反击$()是一个盾牌魔咒。$(p)它使所有被格挡的攻击对攻击者造成部分伤害。$(p)更确切地说，被格挡的伤害有15%被反弹回来。"
+            "text": "$(9)盾反$()是一个盾牌魔咒。$(p)它使所有被格挡的攻击对攻击者造成部分伤害。$(p)更确切地说，被格挡的伤害有15%被反弹回来。"
         },
 		{
             "type": "patchouli:text",
-            "text": "反弹的伤害会转化为魔法伤害。$(p)足够高的$(9)防御反击$()等级会造成比原来更多的伤害。"
+            "text": "反弹的伤害会转化为魔法伤害。$(p)足够高的$(9)盾反$()等级会造成比原来更多的伤害。"
         }
 	]
 }


### PR DESCRIPTION
<img width="854" height="480" alt="2025-11-09_15 31 05" src="https://github.com/user-attachments/assets/5215db6d-fc78-4ce4-a30e-c53853008ae5" />
I found some gems' tooltip doesn't have some translation keys in 8.4.1, because these gems can be used to shears now.

Additionally, I updated some enchantments' translation in guide book, based on [this PR](https://github.com/Shadows-of-Fire/Apothic-Enchanting/pull/62).