### PR TITLE
Fix space character in AttributeModifier ResourceLocation

### DIFF
--- a/src/main/java/dev/shadowsoffire/apotheosis/mobs/util/EntityModifier.java
+++ b/src/main/java/dev/shadowsoffire/apotheosis/mobs/util/EntityModifier.java
@@ -107,7 +107,7 @@ public interface EntityModifier extends CodecProvider<EntityModifier> {
             if (inst == null) {
                 return;
             }
-            this.modifier.apply(Apotheosis.loc("rm_ " + mob.getRandom().nextInt()), ctx.rand(), mob);
+            this.modifier.apply(Apotheosis.loc("rm_" + mob.getRandom().nextInt()), ctx.rand(), mob);
         }
 
     }


### PR DESCRIPTION
The space caused `ResourceLocationException: Non [a-z0-9/._-] character in path`, preventing mobs from spawning when augmentation was applied.

Related issue: https://github.com/Shadows-of-Fire/Apotheosis/issues/1747